### PR TITLE
improve appearance and positioning of favicons

### DIFF
--- a/stylesheets/web-browser.less
+++ b/stylesheets/web-browser.less
@@ -1,24 +1,26 @@
-  
+
 @import "ui-variables";
 @import "octicon-utf-codes";
 
+@faviconsize: 16px;
 .tab-bar .tab .tab-favicon {
   position: absolute;
   left:   .5em;
-  top:    .5em;
-  width:  1.6em;
-  height: 1.6em;
+  top:    50%;
+  width:  @faviconsize;
+  height: @faviconsize;
+  margin-top: @faviconsize / -2;
 }
 
 .workspace .browser-toolbar {
   display:    flex;
   position:   relative;
   height:     34px;
-  font-size:  14px; 
-  background-image: -webkit-linear-gradient(top, @app-background-color, 
+  font-size:  14px;
+  background-image: -webkit-linear-gradient(top, @app-background-color,
                                                     @tab-bar-background-color);
   box-shadow: inset 0 -8px 8px -4px rgba(0, 0, 0, 0.15);
-  
+
   .nav-btns{
     display: inline-block;
     position: relative;
@@ -26,7 +28,7 @@
     height: 1.1em;
     line-height: 1.3em;
     line-height: 0.9;
-    
+
     .octicon {
       font-family: 'Octicons Regular';
       font-size: 1.7em;
@@ -64,20 +66,20 @@
   .omnibox-container {
     flex: 1;
     order: 3;
-    
+
     .omnibox {
       position: relative;
       margin-left: .4em;
       margin-right: .4em;
-      
+
       input {
-        position:   relative; 
-        top:            .3em; 
+        position:   relative;
+        top:            .3em;
         height:        1.7em;
         width:          100%;
         padding-left:  0.3em;
         padding-right: 0.2em;
-        font-size:      14px; 
+        font-size:      14px;
         box-shadow:     none;
         border:        1px solid @input-border-color;
         color:          @text-color;
@@ -104,4 +106,3 @@
     margin: 5px;
   }
 }
-


### PR DESCRIPTION
By convention favicons are 16x16px. Em based sizing will stretch many non-vector favicons into a blur in many situations. Also, a px based layout makes it easier to vertically center the icons in the tab by using `top:50%` and a negative margin of halve the icon size.

Before:
![screen shot 2015-02-07 at 12 20 59](https://cloud.githubusercontent.com/assets/2543659/6091910/cdc87064-aec3-11e4-88ad-572b87e11f2b.png)

After:
![screen shot 2015-02-07 at 12 20 41](https://cloud.githubusercontent.com/assets/2543659/6091909/cda748d0-aec3-11e4-8bd6-813987250e63.png)


Oh, and apparently Atom cleaned up some whitespace, hope you don't mind.